### PR TITLE
route_failover returns SERVER_ERROR bad response on a miss

### DIFF
--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -870,7 +870,7 @@ local function route_failover_f(rctx, arg)
         return function(r)
             local res = nil
             for i=1, limit do
-                local res = rctx:enqueue_and_wait(r, t[i])
+                res = rctx:enqueue_and_wait(r, t[i])
                 if (miss == true and res:hit()) or (miss == false and res:ok()) then
                     return res
                 end


### PR DESCRIPTION
I configured route_failover as follows:
routes{
    cmap = {
        [mcp.CMD_GET] = route_failover{
            children = { "cloud358734988fd0", "cloud358734988fd1", "cloud358734988fd2" },
            failover_count = 3,
            miss = true,
        },
       
    },
}

a get command returns the data if it exists in at least one pool but returns "SERVER_ERROR bad response" if there is a miss. Is it possible to return the best response like if the first pool returns a miss and the last pool returns an error, then in this case the response should be a miss.