### PR TITLE
routelib: new cmap support

### DIFF
--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -86,5 +86,15 @@ routes{
         direct_c = route_direct{
             child = "baz",
         },
+        d_submap = cmdmap{
+            mg = route_direct{ child = "foo" },
+            md = route_direct{ child = "bar" },
+            ma = route_direct{ child = "baz" },
+        },
     },
+    cmap = {
+        mg = route_direct{ child = "baz" },
+        md = route_direct{ child = "bar" },
+        ma = route_direct{ child = "foo" },
+    }
 }

--- a/lib/routelib/t/routes.lua
+++ b/lib/routelib/t/routes.lua
@@ -42,6 +42,47 @@ function clearAll(p)
     p:clear()
 end
 
+TestCmaps = {}
+
+function TestCmaps:testSub()
+    p:c_send("mg d_submap/a t\r\n")
+    p:be_recv_c(1, "mg to first be")
+    p:be_send(1, "HD t31\r\n")
+    p:c_recv_be()
+
+    p:c_send("md d_submap/a\r\n")
+    p:be_recv_c(2, "md to second be")
+    p:be_send(2, "HD\r\n")
+    p:c_recv_be()
+
+    p:c_send("ma d_submap/a\r\n")
+    p:be_recv_c(3, "ma to third be")
+    p:be_send(3, "HD\r\n")
+    p:c_recv_be()
+
+    clearAll(p)
+end
+
+-- "top level" route cmap as fallback for unknown map entry
+function TestCmaps:testTop()
+    p:c_send("mg badroute/a t\r\n")
+    p:be_recv_c(3, "mg to third be")
+    p:be_send(3, "HD t32\r\n")
+    p:c_recv_be()
+
+    p:c_send("md badroute/a\r\n")
+    p:be_recv_c(2, "md to second be")
+    p:be_send(2, "HD\r\n")
+    p:c_recv_be()
+
+    p:c_send("ma badroute/a\r\n")
+    p:be_recv_c(1, "ma to first be")
+    p:be_send(1, "HD\r\n")
+    p:c_recv_be()
+
+    clearAll(p)
+end
+
 -- we have three pools configured but set failover limit to 2
 TestMissFailover = {}
 


### PR DESCRIPTION
allows falling back from map -> cmap -> default
simplifies internal usage of cmap-only routes

adds string aliases for command maps to make them less gross:

```
foo = cmdmap{
  mg = route_etc{},
  ms = route_etc{},
}
```

vs the [mcp.CMD_MG] stuff from before.