### PR TITLE
Issue #13: Updated route_failover to treat miss flag to return best on error.

### DIFF
--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -909,9 +909,10 @@ local function route_failover_f(rctx, arg)
     end
 
     return function(r)
-        local result = nil
+        local res = nil
+        local rmiss = nil -- flag if we any children returned a miss
         for i=1, limit do
-            local res = rctx:enqueue_and_wait(r, t[i])
+            res = rctx:enqueue_and_wait(r, t[i])
             if i > 1 and s then
                 -- increment the retries counter
                 s(s_id, 1)
@@ -919,27 +920,23 @@ local function route_failover_f(rctx, arg)
 
             -- process result
             if res:hit() then
-                -- return hit
                 return res
             elseif res:ok() then
                 if miss == true then
-                    -- save the ok result and continue looping as we treat misses as failures
-                    result = res
+                    -- save the ok/miss result and continue looping (treat miss as a failure)
+                    rmiss = res
                 else
-                    -- return ok as we treat miss as a good result
+                    -- return ok/miss (treat miss as a good result)
                     return res
-                end
-            else
-                -- for miss==false save the last error (treating misses as a good result)
-                -- for miss==true  save the last error only if nothing better was previously saved
-                if result == nil or miss == false or not result:ok() then
-                    result = res
                 end
             end
         end
 
-        -- didn't get what we want, return the best between misses and errors we got
-        return result
+        -- didn't get what we want, return either miss (if any) or last error
+        if rmiss then
+            return rmiss
+        end
+        return res
     end
 end
 

--- a/lib/routelib/t/routes.lua
+++ b/lib/routelib/t/routes.lua
@@ -201,6 +201,26 @@ function TestMissFailover:testFailure()
     clearAll(p)
 end
 
+function TestMissFailover:testBestResult()
+    p:c_send("mg failover/a t\r\n")
+    p:be_recv_c(1, "first be got miss")
+    p:be_send(1, "EN\r\n")
+    p:be_recv_c(2, "second be got error")
+    p:be_send(2, "SERVER_ERROR last error\r\n")
+    p:c_recv("EN\r\n") -- The client should receive "best result" out of two, which is miss-response from the first be
+    clearAll(p)
+end
+
+function TestMissFailover:testLastError()
+    p:c_send("mg failover/a t\r\n")
+    p:be_recv_c(1, "first be got error-1")
+    p:be_send(1, "SERVER_ERROR error-1\r\n")
+    p:be_recv_c(2, "second be got error-2")
+    p:be_send(2, "SERVER_ERROR error-2\r\n")
+    p:c_recv("SERVER_ERROR error-2\r\n") -- The client should receive the last error if all bes return errors
+    clearAll(p)
+end
+
 -- we have three pools configured but set failover limit to 2
 TestMissFailoverPSET = {}
 


### PR DESCRIPTION
Updated route_failover to treat miss flag to return best result on error (return miss if there were misses when requesting key from the list of children.
Issue: https://github.com/memcached/memcached-proxylibs/issues/13