### PR TITLE
Added miss flag to route_allfastest

### DIFF
--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -1155,17 +1155,15 @@ local function route_zfailover_f(rctx, arg)
         rctx:enqueue(r, far)
         rctx:wait_cond(farcount, mode)
 
-        -- wait for a good result if miss==true
-        -- if miss==false, return OK or GOOD, whatever comes first
-        -- return last error if no good or ok comes in
+        -- look for a good result, else any OK, else any result.
         local final = nil
         for x=1, #far do
             local res, tag = rctx:result(far[x])
             if tag == mcp.RES_GOOD then
                 return res
-            elseif tag == mcp.RES_OK and miss == false then
-                return res
-            elseif final == nil or not final:ok() then
+            elseif tag == mcp.RES_OK then
+                final = res
+            elseif final ~= nil then
                 final = res
             end
         end

--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -849,7 +849,7 @@ end
 local function route_allfastest_f(rctx, arg)
     local mode = mcp.WAIT_OK -- wait until first non-error
     if arg.miss then
-        mode = mcp.WAIT_GOOD -- wait until first good or until all childrend return
+        mode = mcp.WAIT_GOOD -- wait until first good or until all children return
     end
 
     dsay("generating an allfastest function")

--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -859,10 +859,10 @@ local function route_allfastest_f(rctx, arg)
         local final = nil
         -- return first good result, or non-error (if nothing good returned), or last error
         for x=1, #arg do
-            local res, mode = rctx:result(arg[x])
-            if mode == mcp.RES_GOOD then
+            local res, tag = rctx:result(arg[x])
+            if tag == mcp.RES_GOOD then
                 return res
-            elseif mode == mcp.RES_OK then
+            elseif tag == mcp.RES_OK then
                 final = res
             elseif final == nil or not final:ok() then
                 final = res
@@ -1155,15 +1155,17 @@ local function route_zfailover_f(rctx, arg)
         rctx:enqueue(r, far)
         rctx:wait_cond(farcount, mode)
 
-        -- look for a good result, else any OK, else any result.
+        -- wait for a good result if miss==true
+        -- if miss==false, return OK or GOOD, whatever comes first
+        -- return last error if no good or ok comes in
         local final = nil
         for x=1, #far do
             local res, tag = rctx:result(far[x])
             if tag == mcp.RES_GOOD then
                 return res
-            elseif tag == mcp.RES_OK then
-                final = res
-            elseif final ~= nil then
+            elseif tag == mcp.RES_OK and miss == false then
+                return res
+            elseif final == nil or not final:ok() then
                 final = res
             end
         end

--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -95,11 +95,6 @@ routes{
             stats = true,
             miss = true,
         },
-        zfailovernomiss = route_zfailover{
-            children = "set_all",
-            stats = true,
-            miss = false,
-        },
         -- used to test if each backend has a clear pipeline
         direct_a = route_direct{
             child = "foo",

--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -95,6 +95,11 @@ routes{
             stats = true,
             miss = true,
         },
+        zfailovernomiss = route_zfailover{
+            children = "set_all",
+            stats = true,
+            miss = false,
+        },
         -- used to test if each backend has a clear pipeline
         direct_a = route_direct{
             child = "foo",

--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -80,7 +80,12 @@ routes{
             },
         },
         allfastest = route_allfastest{
-            children = { "foo", "bar", "baz" }
+            children = { "foo", "bar", "baz" },
+            miss = true,
+        },
+        allfastestnomiss = route_allfastest{
+            children = { "foo", "bar", "baz" },
+            miss = false,
         },
         allsync = route_allsync{
             children = { "foo", "bar", "baz" }

--- a/lib/routelib/t/routes.lua
+++ b/lib/routelib/t/routes.lua
@@ -536,41 +536,21 @@ TestZFailover = {}
 -- first/second/third in the list.
 local LZ = 2
 local FZ = {1, 3} -- far zones
-function TestZFailover:testLocalHit()
+function TestZFailover:testHit()
     p:c_send("mg zfailover/a t\r\n")
     p:be_recv_c(LZ, "local zone got first attempt")
-    p:be_send(LZ, "HD t2\r\n")
+    p:be_send(LZ, "HD t7\r\n")
     p:c_recv_be("got resp from first zone")
     clearAll(p)
 end
 
-function TestZFailover:testFarHit()
+function TestZFailover:testMiss()
     p:c_send("mg zfailover/a t\r\n")
     p:be_recv_c(LZ, "local zone got first attempt")
     p:be_send(LZ, "EN\r\n")
     p:be_recv_c(FZ, "far zones both got requests")
-    p:be_send(1, "EN\r\n")
-    p:be_send(3, "HD t3\r\n")
-    p:c_recv("HD t3\r\n", "got hit response from the second far zone ignoring local and first far miss")
-    clearAll(p)
-end
-
-function TestZFailover:testLocalMissNoMiss()
-    p:c_send("mg zfailovernomiss/a t\r\n")
-    p:be_recv_c(LZ, "local zone got first attempt")
-    p:be_send(LZ, "EN\r\n")
-    p:c_recv("EN\r\n", "got miss response from the local zone as miss==false")
-    clearAll(p)
-end
-
-function TestZFailover:testFarMissNoMiss()
-    p:c_send("mg zfailovernomiss/a t\r\n")
-    p:be_recv_c(LZ, "local zone got first attempt")
-    p:be_send(LZ, "SERVER_ERROR LZ\r\n") -- ignoring error from local zone
-    p:be_recv_c(FZ, "far zones both got requests")
-    p:be_send(1, "EN\r\n")
-    p:be_send(3, "HD t3\r\n")
-    p:c_recv("EN\r\n", "got miss response from the first far zone as miss==false")
+    p:be_send(FZ, "HD t9\r\n")
+    p:c_recv_be("got resp from far zones")
     clearAll(p)
 end
 

--- a/lib/routelib/t/routes.lua
+++ b/lib/routelib/t/routes.lua
@@ -536,21 +536,41 @@ TestZFailover = {}
 -- first/second/third in the list.
 local LZ = 2
 local FZ = {1, 3} -- far zones
-function TestZFailover:testHit()
+function TestZFailover:testLocalHit()
     p:c_send("mg zfailover/a t\r\n")
     p:be_recv_c(LZ, "local zone got first attempt")
-    p:be_send(LZ, "HD t7\r\n")
+    p:be_send(LZ, "HD t2\r\n")
     p:c_recv_be("got resp from first zone")
     clearAll(p)
 end
 
-function TestZFailover:testMiss()
+function TestZFailover:testFarHit()
     p:c_send("mg zfailover/a t\r\n")
     p:be_recv_c(LZ, "local zone got first attempt")
     p:be_send(LZ, "EN\r\n")
     p:be_recv_c(FZ, "far zones both got requests")
-    p:be_send(FZ, "HD t9\r\n")
-    p:c_recv_be("got resp from far zones")
+    p:be_send(1, "EN\r\n")
+    p:be_send(3, "HD t3\r\n")
+    p:c_recv("HD t3\r\n", "got hit response from the second far zone ignoring local and first far miss")
+    clearAll(p)
+end
+
+function TestZFailover:testLocalMissNoMiss()
+    p:c_send("mg zfailovernomiss/a t\r\n")
+    p:be_recv_c(LZ, "local zone got first attempt")
+    p:be_send(LZ, "EN\r\n")
+    p:c_recv("EN\r\n", "got miss response from the local zone as miss==false")
+    clearAll(p)
+end
+
+function TestZFailover:testFarMissNoMiss()
+    p:c_send("mg zfailovernomiss/a t\r\n")
+    p:be_recv_c(LZ, "local zone got first attempt")
+    p:be_send(LZ, "SERVER_ERROR LZ\r\n") -- ignoring error from local zone
+    p:be_recv_c(FZ, "far zones both got requests")
+    p:be_send(1, "EN\r\n")
+    p:be_send(3, "HD t3\r\n")
+    p:c_recv("EN\r\n", "got miss response from the first far zone as miss==false")
     clearAll(p)
 end
 

--- a/lib/routelib/t/routes.lua
+++ b/lib/routelib/t/routes.lua
@@ -425,7 +425,7 @@ function TestAllFastest:testIgnoreMissAndErr()
     p:c_send("mg allfastest/b t\r\n")
     p:be_recv_c({1, 2, 3}, "all three got request")
     p:be_send(1, "SERVER_ERROR too many potatos\r\n")
-    p:be_send(2, "END\r\n") -- should ignore the "miss" response with miss==true flag
+    p:be_send(2, "EN\r\n") -- should ignore "miss" response when miss==true flag is set
     p:be_send(3, "HD t3\r\n")
     p:c_recv("HD t3\r\n")
     clearAll(p)
@@ -435,9 +435,9 @@ function TestAllFastest:testReturnMiss()
     p:c_send("mg allfastestnomiss/b t\r\n")
     p:be_recv_c({1, 2, 3}, "all three got request")
     p:be_send(1, "SERVER_ERROR too many potatos\r\n")
-    p:be_send(2, "END\r\n") -- should return "miss" response with miss==false flag
+    p:be_send(2, "EN\r\n") -- should return "miss" response when miss==false
     p:be_send(3, "HD t3\r\n")
-    p:c_recv("END\r\n")
+    p:c_recv("EN\r\n")
     clearAll(p)
 end
 
@@ -456,7 +456,7 @@ function TestAllFastest:testMiddleHit()
     p:be_recv_c({1, 2, 3}, "all three got request")
     p:be_send(1, "SERVER_ERROR one\r\n")
     p:be_send(2, "HD t5\r\n")
-    p:be_send(3, "SERVER_ERROR final\r\n")
+    p:be_send(3, "EN\r\n")
     p:c_recv("HD t5\r\n")
     clearAll(p)
 end
@@ -465,9 +465,9 @@ function TestAllFastest:testMiddleMiss()
     p:c_send("mg allfastest/d t\r\n")
     p:be_recv_c({1, 2, 3}, "all three got request")
     p:be_send(1, "SERVER_ERROR one\r\n")
-    p:be_send(2, "END\r\n")
+    p:be_send(2, "EN\r\n")
     p:be_send(3, "SERVER_ERROR final\r\n")
-    p:c_recv("END\r\n")
+    p:c_recv("EN\r\n")
     clearAll(p)
 end
 
@@ -475,9 +475,9 @@ function TestAllFastest:testNoMissIgnoreLastHit()
     p:c_send("mg allfastestnomiss/d t\r\n")
     p:be_recv_c({1, 2, 3}, "all three got request")
     p:be_send(1, "SERVER_ERROR one\r\n")
-    p:be_send(2, "END\r\n")
+    p:be_send(2, "EN\r\n") -- if miss==false, the first ok is returned ignoring subsequent hits
     p:be_send(3, "HD t5\r\n")
-    p:c_recv("END\r\n") -- with miss==false, the first ok is returned ignoring subsequent hits
+    p:c_recv("EN\r\n")
     clearAll(p)
 end
 


### PR DESCRIPTION
Miss flag helps with using route_allfastest for executing parallel reads. Miss flag does not change write operations. For reads:
- If miss==false, route_allfastest returns the first hit or miss, whatever comes first.
- If miss==true,  route_allfastest waits for a hit and returns it. If no hit, it returns a miss (if any) or an error (if only errors returned by children).