### PR TITLE
New routes and various fixes.

### DIFF
--- a/lib/routelib/examples/logging.lua
+++ b/lib/routelib/examples/logging.lua
@@ -1,0 +1,28 @@
+settings{
+    backend_options = {
+        zlog = {
+            rate = 5, -- log one out of every 5 by random chance
+            errors = true, -- log all errors
+            deadline = 250, -- log all results slower than 250ms
+            tag = "all" -- informational tag for log
+        }
+    }
+}
+
+pools{
+    main = {
+        -- per-pool logging options.
+        --[[backend_options = {
+            -- if no constraints given, log everything (SLOW!)
+            log = { tag = "mainpool" }
+        },--]]
+        backends = {
+            "127.0.0.1:11214",
+            "127.0.0.1:11215",
+        }
+    }
+}
+
+routes{
+    default = route_direct{ child = "main" }
+}

--- a/lib/routelib/examples/zfailover.lua
+++ b/lib/routelib/examples/zfailover.lua
@@ -4,6 +4,8 @@ debug(true)
 -- TODO: example of pulling from envvar
 -- set our local zone for the file.
 local_zone("foo")
+--local_zone_from_env("MCZONE")
+--local_zone_from_file("./zonefile.txt")
 
 -- "z" versions of route handlers are "zone" aware. If given a set of pools
 -- where one is "near" to the router and others are "far", it will attempt to

--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -224,6 +224,8 @@ local function settings_parse(a)
             func(value)
         elseif setting == "pool_options" then
             M.pool_options = value
+        elseif setting == "backend_options" then
+            M.backend_options = value
         end
     end
 end
@@ -301,7 +303,21 @@ local function pools_make(conf)
         end
     end
 
-    local bopts = conf.backend_options
+    local bopts = {}
+    -- seed global overrides
+    if M.backend_options then
+        for k, v in pairs(M.backend_options) do
+            dsay("backend option using global override:", k, v)
+            bopts[k] = v
+        end
+    end
+    if conf.backend_options then
+        for k, v in pairs(conf.backend_options) do
+            dsay("backend option using local override:", k, v)
+            bopts[k] = v
+        end
+    end
+
     local s = {}
     -- TODO: some convenience functions for asserting?
     -- die more gracefully if backend list missing

--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -42,6 +42,21 @@ local function dump(o)
    end
 end
 
+local function dump_pretty(o, indent)
+    indent = indent or ""
+    if type(o) == 'table' then
+        local s = '{\n'
+        local next_indent = indent .. "    "
+        for k,v in pairs(o) do
+            if type(k) ~= 'number' then k = '"'..k..'"' end
+            s = s .. next_indent .. '['..k..'] = ' .. dump_pretty(v, next_indent) .. ',\n'
+        end
+        return s .. indent .. '}'
+    else
+        return tostring(o)
+    end
+end
+
 -- classes for typing.
 -- NOTE: metatable classes do not cross VM's, so they may only be used in the
 -- same VM they were assigned (pools or routes)
@@ -86,7 +101,7 @@ end
 function pools(a)
     if M.is_debug then
         print("pools config:")
-        print(dump(a))
+        print(dump_pretty(a))
     end
     -- merge the list so pools{} can be called multiple times
     local p = M.c_in.pools
@@ -97,7 +112,7 @@ end
 
 function routes(a)
     dsay("routes:")
-    dsay(dump(a))
+    dsay(dump_pretty(a))
     if a["conf"] == nil then
         a["conf"] = {}
     end

--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -124,7 +124,34 @@ function find_pools(m)
 end
 
 function local_zone(zone)
-    dsay(zone)
+    if zone then
+        dsay("=== local zone: ", zone)
+        M.c_in.local_zone = zone
+    else
+        return M.c_in.local_zone
+    end
+end
+
+function local_zone_from_env(envname)
+    local zone = os.getenv(envname)
+    if zone == nil then
+        error("failed to get local zone from environment variable: " .. envname)
+    end
+    dsay("=== local zone: ", zone)
+    M.c_in.local_zone = zone
+end
+
+function local_zone_from_file(filename)
+    local f, err, errno = io.open(filename, "r")
+    if f == nil then
+        error("failure while opening local zone file: " .. filename .. " " .. err)
+    end
+    local zone = f:read("l")
+    f:close()
+    if zone == nil then
+        error("failed to read local zone from file: " .. filename)
+    end
+    dsay("=== local zone: ", zone)
     M.c_in.local_zone = zone
 end
 

--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -317,6 +317,9 @@ end
 local function pools_parse(a)
     local pools = {}
     for name, conf in pairs(a) do
+        if name == "internal" then
+            error("pool name 'internal' is reserved, please use another name")
+        end
         -- Check if conf is a pool set or single pool.
         -- Add result to top level pools[name] either way.
         if string.find(name, "^set_") ~= nil then
@@ -627,6 +630,11 @@ local function make_router(set, pools)
         get_child = function(self, child)
             if type(child) ~= "string" then
                 error("invalid child given to route handler: " .. type(child))
+            end
+
+            -- shortcut for the process-internal cache.
+            if child == "internal" then
+                return mcp.internal_handler
             end
 
             -- if "^set_words_etc" then special parse

--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -1563,6 +1563,38 @@ end
 -- route_ratelim end
 --
 
+--
+-- route_random start
+--
+
+function route_random_conf(t)
+    return t
+end
+
+function route_random_start(a, ctx, fgen)
+    local handles = {}
+    local count = 0
+
+    for k, child in pairs(a.children) do
+        table.insert(handles, fgen:new_handle(child))
+        count = count + 1
+    end
+
+    fgen:ready({
+        n = ctx:label(),
+        f = function(rctx)
+            return function(r)
+                local pool = handles[math.random(count)]
+                return rctx:enqueue_and_wait(r, pool)
+            end
+        end
+    })
+end
+
+--
+-- route_random end
+--
+
 register_route_handlers({
     "failover",
     "allfastest",
@@ -1572,5 +1604,6 @@ register_route_handlers({
     "zfailover",
     "ttl",
     "null",
-    "ratelim"
+    "ratelim",
+    "random"
 })

--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -99,10 +99,6 @@ function settings(a)
 end
 
 function pools(a)
-    if M.is_debug then
-        print("pools config:")
-        print(dump_pretty(a))
-    end
     -- merge the list so pools{} can be called multiple times
     local p = M.c_in.pools
     for k, v in pairs(a) do
@@ -111,8 +107,6 @@ function pools(a)
 end
 
 function routes(a)
-    dsay("routes:")
-    dsay(dump_pretty(a))
     if a["conf"] == nil then
         a["conf"] = {}
     end
@@ -772,6 +766,19 @@ end
 -- mcp_config_pools executes from the configuration thread
 -- mcp_config_routes executes from each worker thread
 
+function mcp_config_dump_state(c)
+    if M.is_debug then
+        dsay("======== GLOBAL SETTINGS CONFIG ========")
+        dsay(dump_pretty(c.settings))
+
+        dsay("======== POOLS CONFIG ========")
+        dsay(dump_pretty(c.pools))
+
+        dsay("======== ROUTES CONFIG ========")
+        dsay(dump_pretty(c.routes))
+    end
+end
+
 function mcp_config_pools()
     load_userconfig(mcp.start_arg)
     dsay("=== mcp_config_pools: start ===")
@@ -781,6 +788,7 @@ function mcp_config_pools()
     if M.c_in.settings then
         settings_parse(M.c_in.settings)
     end
+    mcp_config_dump_state(M.c_in)
 
     -- Step 1) create pool objects
     local pools = pools_parse(M.c_in.pools)

--- a/lib/routelib/t/lib/memcachedtest.lua
+++ b/lib/routelib/t/lib/memcachedtest.lua
@@ -29,14 +29,14 @@ end
 -- if it's less convenient in the future it can change :P
 local function _poll_read_n(fdlist, timeout)
     local fds = {}
-    for fd, _ in ipairs(fdlist) do
+    for fd, _ in pairs(fdlist) do
         fds[fd] = {events={IN=true}}
     end
     local ready = poll.poll(fds, timeout)
 
     if ready then
         local res = {}
-        for fd, v in ipairs(fds) do
+        for fd, v in pairs(fds) do
             if v.revents and v.revents.IN then
                 table.insert(res, fd)
             end

--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -139,7 +139,9 @@ routes{
             tickrate = 20000,
             fail_until_limit = true,
         },
-
+        random = route_random{
+            children = "set_arr"
+        },
     },
     cmap = {
         mg = route_direct{ child = "baz" },

--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -132,6 +132,14 @@ routes{
             fillrate = 4,
             tickrate = 20000,
         },
+        rateliminv = route_ratelim{
+            child = "foo",
+            limit = 10,
+            fillrate = 4,
+            tickrate = 20000,
+            fail_until_limit = true,
+        },
+
     },
     cmap = {
         mg = route_direct{ child = "baz" },

--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -1,6 +1,6 @@
 --verbose(true)
 --debug(true)
-local_zone("zbar")
+--local_zone("zbar")
 
 settings{
     backend_connect_timeout = 3,
@@ -67,6 +67,10 @@ routes{
             children = "set_arr",
             miss = true,
         },
+        failoverzone = route_failover{
+            children = "set_all",
+            local_zone = "zbar",
+        },
         split = route_split{
             child_a = "foo",
             child_b = "bar",
@@ -91,6 +95,7 @@ routes{
             children = { "foo", "bar", "baz" }
         },
         zfailover = route_zfailover{
+            local_zone = "zbar",
             children = "set_all",
             stats = true,
             miss = true,

--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -126,6 +126,12 @@ routes{
         internal = route_direct{
             child = "internal",
         },
+        ratelim = route_ratelim{
+            child = "foo",
+            limit = 10,
+            fillrate = 4,
+            tickrate = 20000,
+        },
     },
     cmap = {
         mg = route_direct{ child = "baz" },

--- a/lib/routelib/t/routes-config.lua
+++ b/lib/routelib/t/routes-config.lua
@@ -123,6 +123,9 @@ routes{
         },
         ttl = route_ttl{ ttl = 45, child = "foo" },
         null = route_null{},
+        internal = route_direct{
+            child = "internal",
+        },
     },
     cmap = {
         mg = route_direct{ child = "baz" },

--- a/lib/routelib/t/routes.lua
+++ b/lib/routelib/t/routes.lua
@@ -611,4 +611,21 @@ function TestZFailover:testMiss()
     clearAll(p)
 end
 
+TestInternal = {}
+
+-- Don't need extensive tests for internal since those are in the main source.
+function TestInternal:testBasic()
+    -- ensure we can talk to the server without answering from a backend
+    -- ourselves.
+    p:c_send("mg internal/a t\r\n")
+    p:c_recv("EN\r\n")
+
+    p:c_send("ms internal/a 2 F50\r\nhi\r\n")
+    p:c_recv("HD\r\n")
+
+    p:c_send("mg internal/a f\r\n")
+    p:c_recv("HD f50\r\n")
+    clearAll(p)
+end
+
 runTests()


### PR DESCRIPTION
- Makes failover zone aware (see commit/test)
- Specifying "internal" as child uses the process-local cache.
- Allow `backend_options` in `settings{}` global overrides
- Adds `route_ratelim` (WIP)
- Adds `route_allasync` to dispatch requests but immediately return (same results as nullroute)

Requires `next` branch of memcached.

TODO:

- need to solve for specifying "a set but without the local zone" and "a set but just the local zone" - maybe just as an option to the routes.
this lets you specify a failover route with local zone, then an allfastest route as the failover child. which then runs all possible failover pools in parallel.

- finish ratelim
hook it up with a nullroute res and do some tests. should be possible to mix with failover to ratelimit access to new thing etc.
should also add an option to invert: return fail until ratelimit has been hit. this would allow you to do a scenario like:
- failover between A and B (then maybe A again). A is remote pool. B is internal pool.
- if rate is below N send gets to A 
- if rate is above N send gets to internal process for extra speed (but potential staleness/etc).
- there other potential uses but just throwing out an example.