### PR TITLE
Fix argument copying for wrapped routes

### DIFF
--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -427,8 +427,8 @@ local function configure_route_wrap(r, ctx)
         end
         rn.a = {}
         -- then shallow copy of the argument list
-        for k, v in pairs(rn.a) do
-            rn.a[k] = r.a[k]
+        for k, v in pairs(r.a) do
+            rn.a[k] = v
         end
 
         -- reuse the same route config, but once for each child.


### PR DESCRIPTION
When fanning out the source route to all destination routes, the code was previously iterating over the arguments of the given _destination route_, when it should have been iterating over the arguments of the _source route_. Make that patch here.