### PR TITLE
Add method to allow retrieval of listener tag during pool configuration

### DIFF
--- a/lib/routelib/routelib.lua
+++ b/lib/routelib/routelib.lua
@@ -536,7 +536,7 @@ end
 -- routes that have stats should assign stats or global overrides in this conf
 -- stage.
 -- NOTE: we are editing the entries in-place
-local function main_configure_router(set, pools, c_in)
+local function main_configure_router(set, pools, c_in, tag)
     -- create ctx object to hold label + command
     local ctx = {
         label = function(self)
@@ -544,6 +544,9 @@ local function main_configure_router(set, pools, c_in)
         end,
         cmd = function(self)
             return self._cmd
+        end,
+        listen_tag = function(self)
+            return self._listen_tag
         end,
         check_child = function(self, child)
             -- ensure this child is a string of a valid pool
@@ -610,6 +613,7 @@ local function main_configure_router(set, pools, c_in)
             return id
         end
     }
+    ctx._listen_tag = tag
 
     if set.map then
         -- a prefix map
@@ -679,7 +683,7 @@ local function main_routes_parse(c_in, pools)
             end
         end
 
-        main_configure_router(set, pools, c_in)
+        main_configure_router(set, pools, c_in, tag)
         found = true
     end
 


### PR DESCRIPTION
Allow for a route to retrieve its associated listener tag. This enables us to use the same route across multiple different listeners, and for it to execute execute custom configuration behavior depending on its associated listener.  